### PR TITLE
Upgrade to upstream 1.26.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+* Sync with upstream 1.26.0 chart
+* bump components versions
+  * azurefile-csi to `1.26.0`
+  * csi-provisioner to `3.3.0`
+  * csi-attacher to `4.0.0`
+  * csi-resizer to `1.6.0`
+  * livenessprobe to `2.8.0`
+  * csi-node-driver-registrar to `2.6.2`
+* increase api qps limit of csi-provisioner and csi-attacher 
+* increase api qps for azurefile kubeclient
+* add support for labels, annotations, podLabels and podAnnotations 
+* Remove `list` rbac for secrets
+* add node-role.kubernetes.io/control-plane toleration
+* add support for http/s proxy 
+
 ## [1.20.0-gs1] - 2022-08-29
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 * Remove `list` rbac for secrets
 * add node-role.kubernetes.io/control-plane toleration
 * add support for http/s proxy 
+* Make `AZURE_CREDENTIAL_FILE` depends on `.Values.provider` 
 
 ## [1.20.0-gs1] - 2022-08-29
 

--- a/helm/azurefile-csi-driver-app/Chart.yaml
+++ b/helm/azurefile-csi-driver-app/Chart.yaml
@@ -1,11 +1,10 @@
 apiVersion: v1
-appVersion: 1.20.0
+appVersion: 1.26.0
 description: A Helm chart to run Azure CSI driver for Azure File.
 icon: https://s.giantswarm.io/app-icons/azure/1/dark.svg
 home: https://github.com/giantswarm/azurefile-csi-driver-app
 name: azurefile-csi-driver-app
-version: 0.0.0-dev
-#version: [[ .Version ]]
+version: [[ .Version ]]
 restrictions:
   clusterSingleton: true
   fixedNamespace: kube-system

--- a/helm/azurefile-csi-driver-app/Chart.yaml
+++ b/helm/azurefile-csi-driver-app/Chart.yaml
@@ -4,7 +4,8 @@ description: A Helm chart to run Azure CSI driver for Azure File.
 icon: https://s.giantswarm.io/app-icons/azure/1/dark.svg
 home: https://github.com/giantswarm/azurefile-csi-driver-app
 name: azurefile-csi-driver-app
-version: [[ .Version ]]
+version: 0.0.0-dev
+#version: [[ .Version ]]
 restrictions:
   clusterSingleton: true
   fixedNamespace: kube-system

--- a/helm/azurefile-csi-driver-app/templates/csi-azurefile-controller.yaml
+++ b/helm/azurefile-csi-driver-app/templates/csi-azurefile-controller.yaml
@@ -6,6 +6,13 @@ metadata:
   labels:
     app: {{ .Values.controller.name }}
     {{- include "azurefile.labels" . | nindent 4 }}
+{{- with .Values.controller.labels }}
+{{ . | toYaml | indent 4 }}
+{{- end }}
+{{- with .Values.controller.annotations }}
+  annotations:
+{{ . | toYaml | indent 4 }}
+{{- end }}
 spec:
   replicas: {{ .Values.controller.replicas }}
   selector:
@@ -17,6 +24,13 @@ spec:
       labels:
         {{- include "azurefile.labels" . | nindent 8 }}
         app: {{ .Values.controller.name }}
+{{- with .Values.controller.podLabels }}
+{{ toYaml . | indent 8 }}
+{{- end }}
+{{- with .Values.controller.podAnnotations }}
+      annotations:
+{{ toYaml . | indent 8 }}
+{{- end }}
     spec:
       hostNetwork: {{ .Values.controller.hostNetwork }}
       serviceAccountName: {{ .Values.serviceAccount.controller }}
@@ -58,6 +72,8 @@ spec:
             - "--leader-election-namespace={{ .Release.Namespace }}"
             - "--timeout=300s"
             - "--extra-create-metadata=true"
+            - "--kube-api-qps=50"
+            - "--kube-api-burst=100"
           env:
             - name: ADDRESS
               value: /csi/csi.sock
@@ -78,6 +94,8 @@ spec:
             - "-timeout=120s"
             - "-leader-election"
             - "--leader-election-namespace={{ .Release.Namespace }}"
+            - "--kube-api-qps=50"
+            - "--kube-api-burst=100"
           env:
             - name: ADDRESS
               value: /csi/csi.sock
@@ -179,6 +197,14 @@ spec:
               value: /etc/kubernetes/config/azure.yaml
             - name: CSI_ENDPOINT
               value: unix:///csi/csi.sock
+            {{- if ne .Values.driver.httpsProxy "" }}
+            - name: HTTPS_PROXY
+              value: {{ .Values.driver.httpsProxy }}
+            {{- end }}
+            {{- if ne .Values.driver.httpProxy "" }}
+            - name: HTTP_PROXY
+              value: {{ .Values.driver.httpProxy }}
+            {{- end }}
             - name: AZURE_GO_SDK_LOG_LEVEL
               value: {{ .Values.driver.azureGoSDKLogLevel }}
           imagePullPolicy: {{ .Values.image.azurefile.pullPolicy }}

--- a/helm/azurefile-csi-driver-app/templates/csi-azurefile-controller.yaml
+++ b/helm/azurefile-csi-driver-app/templates/csi-azurefile-controller.yaml
@@ -1,3 +1,4 @@
+{{- $proxy := deepCopy .Values.cluster.proxy |  mustMerge .Values.proxy }}
 kind: Deployment
 apiVersion: apps/v1
 metadata:
@@ -197,13 +198,19 @@ spec:
               value: /etc/kubernetes/config/azure.yaml
             - name: CSI_ENDPOINT
               value: unix:///csi/csi.sock
-            {{- if ne .Values.driver.httpsProxy "" }}
-            - name: HTTPS_PROXY
-              value: {{ .Values.driver.httpsProxy }}
-            {{- end }}
-            {{- if ne .Values.driver.httpProxy "" }}
+            {{- if and $proxy.noProxy $proxy.http $proxy.https }}
+            - name: NO_PROXY
+              value: {{ $proxy.noProxy }}
+            - name: no_proxy
+              value: {{ $proxy.noProxy }}
             - name: HTTP_PROXY
-              value: {{ .Values.driver.httpProxy }}
+              value: {{ $proxy.http }}
+            - name: http_proxy
+              value: {{ $proxy.http }}
+            - name: HTTPS_PROXY
+              value: {{ $proxy.https }}
+            - name: https_proxy
+              value: {{ $proxy.https }}
             {{- end }}
             - name: AZURE_GO_SDK_LOG_LEVEL
               value: {{ .Values.driver.azureGoSDKLogLevel }}

--- a/helm/azurefile-csi-driver-app/templates/csi-azurefile-controller.yaml
+++ b/helm/azurefile-csi-driver-app/templates/csi-azurefile-controller.yaml
@@ -195,7 +195,7 @@ spec:
             periodSeconds: 30
           env:
             - name: AZURE_CREDENTIAL_FILE
-              value: /etc/kubernetes/config/azure.yaml
+              value: {{ if eq .Values.provider "capz" }}/etc/kubernetes/azure.json{{ else }}/etc/kubernetes/config/azure.yaml{{ end }}
             - name: CSI_ENDPOINT
               value: unix:///csi/csi.sock
             {{- if and $proxy.noProxy $proxy.http $proxy.https }}

--- a/helm/azurefile-csi-driver-app/templates/csi-azurefile-controller.yaml
+++ b/helm/azurefile-csi-driver-app/templates/csi-azurefile-controller.yaml
@@ -195,7 +195,7 @@ spec:
             periodSeconds: 30
           env:
             - name: AZURE_CREDENTIAL_FILE
-              value: {{ if eq .Values.provider "capz" }}/etc/kubernetes/azure.json{{ else }}/etc/kubernetes/config/azure.yaml{{ end }}
+              value: {{ .Values.linux.azure_credential_file | default ( ternary "/etc/kubernetes/azure.json" "/etc/kubernetes/config/azure.yaml" (eq .Values.provider "capz") ) }}
             - name: CSI_ENDPOINT
               value: unix:///csi/csi.sock
             {{- if and $proxy.noProxy $proxy.http $proxy.https }}

--- a/helm/azurefile-csi-driver-app/templates/csi-azurefile-node-windows.yaml
+++ b/helm/azurefile-csi-driver-app/templates/csi-azurefile-node-windows.yaml
@@ -7,6 +7,13 @@ metadata:
   labels:
     app: {{ .Values.windows.dsName }}
     {{- include "azurefile.labels" . | nindent 4 }}
+{{- with .Values.windows.labels }}
+{{ . | toYaml | indent 4 }}
+{{- end }}
+{{- with .Values.windows.annotations }}
+  annotations:
+{{ . | toYaml | indent 4 }}
+{{- end }}
 spec:
   updateStrategy:
     rollingUpdate:
@@ -21,6 +28,13 @@ spec:
       labels:
         app: {{ .Values.windows.dsName }}
         {{- include "azurefile.labels" . | nindent 8 }}
+{{- with .Values.windows.podLabels }}
+{{ toYaml . | indent 8 }}
+{{- end }}
+{{- with .Values.windows.podAnnotations }}
+      annotations:
+{{ toYaml . | indent 8 }}
+{{- end }}
     spec:
       serviceAccountName: {{ .Values.serviceAccount.node }}
 {{- with .Values.windows.tolerations }}
@@ -140,6 +154,14 @@ spec:
                   optional: true
             - name: CSI_ENDPOINT
               value: unix://C:\\csi\\csi.sock
+            {{- if ne .Values.driver.httpsProxy "" }}
+            - name: HTTPS_PROXY
+              value: {{ .Values.driver.httpsProxy }}
+            {{- end }}
+            {{- if ne .Values.driver.httpProxy "" }}
+            - name: HTTP_PROXY
+              value: {{ .Values.driver.httpProxy }}
+            {{- end }}
             - name: KUBE_NODE_NAME
               valueFrom:
                 fieldRef:

--- a/helm/azurefile-csi-driver-app/templates/csi-azurefile-node-windows.yaml
+++ b/helm/azurefile-csi-driver-app/templates/csi-azurefile-node-windows.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.windows.enabled}}
+{{- $proxy := deepCopy .Values.cluster.proxy |  mustMerge .Values.proxy }}
 kind: DaemonSet
 apiVersion: apps/v1
 metadata:
@@ -154,13 +155,19 @@ spec:
                   optional: true
             - name: CSI_ENDPOINT
               value: unix://C:\\csi\\csi.sock
-            {{- if ne .Values.driver.httpsProxy "" }}
-            - name: HTTPS_PROXY
-              value: {{ .Values.driver.httpsProxy }}
-            {{- end }}
-            {{- if ne .Values.driver.httpProxy "" }}
+            {{- if and $proxy.noProxy $proxy.http $proxy.https }}
+            - name: NO_PROXY
+              value: {{ $proxy.noProxy }}
+            - name: no_proxy
+              value: {{ $proxy.noProxy }}
             - name: HTTP_PROXY
-              value: {{ .Values.driver.httpProxy }}
+              value: {{ $proxy.http }}
+            - name: http_proxy
+              value: {{ $proxy.http }}
+            - name: HTTPS_PROXY
+              value: {{ $proxy.https }}
+            - name: https_proxy
+              value: {{ $proxy.https }}
             {{- end }}
             - name: KUBE_NODE_NAME
               valueFrom:

--- a/helm/azurefile-csi-driver-app/templates/csi-azurefile-node.yaml
+++ b/helm/azurefile-csi-driver-app/templates/csi-azurefile-node.yaml
@@ -7,6 +7,13 @@ metadata:
   labels:
     app: {{ .Values.linux.dsName }}
     {{- include "azurefile.labels" . | nindent 4 }}
+{{- with .Values.linux.labels }}
+{{ . | toYaml | indent 4 }}
+{{- end }}
+{{- with .Values.linux.annotations }}
+  annotations:
+{{ . | toYaml | indent 4 }}
+{{- end }}
 spec:
   updateStrategy:
     rollingUpdate:
@@ -21,6 +28,13 @@ spec:
       labels:
         app: {{ .Values.linux.dsName }}
         {{- include "azurefile.labels" . | nindent 8 }}
+{{- with .Values.linux.podLabels }}
+{{ toYaml . | indent 8 }}
+{{- end }}
+{{- with .Values.linux.podAnnotations }}
+      annotations:
+{{ toYaml . | indent 8 }}
+{{- end }}
     spec:
       hostNetwork: true
       dnsPolicy: {{ .Values.linux.dnsPolicy }}
@@ -134,6 +148,14 @@ spec:
                   optional: true
             - name: CSI_ENDPOINT
               value: unix:///csi/csi.sock
+            {{- if ne .Values.driver.httpsProxy "" }}
+            - name: HTTPS_PROXY
+              value: {{ .Values.driver.httpsProxy }}
+            {{- end }}
+            {{- if ne .Values.driver.httpProxy "" }}
+            - name: HTTP_PROXY
+              value: {{ .Values.driver.httpProxy }}
+            {{- end }}
             - name: KUBE_NODE_NAME
               valueFrom:
                 fieldRef:

--- a/helm/azurefile-csi-driver-app/templates/csi-azurefile-node.yaml
+++ b/helm/azurefile-csi-driver-app/templates/csi-azurefile-node.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.linux.enabled}}
+{{- $proxy := deepCopy .Values.cluster.proxy |  mustMerge .Values.proxy }}
 kind: DaemonSet
 apiVersion: apps/v1
 metadata:
@@ -148,13 +149,19 @@ spec:
                   optional: true
             - name: CSI_ENDPOINT
               value: unix:///csi/csi.sock
-            {{- if ne .Values.driver.httpsProxy "" }}
-            - name: HTTPS_PROXY
-              value: {{ .Values.driver.httpsProxy }}
-            {{- end }}
-            {{- if ne .Values.driver.httpProxy "" }}
+            {{- if and $proxy.noProxy $proxy.http $proxy.https }}
+            - name: NO_PROXY
+              value: {{ $proxy.noProxy }}
+            - name: no_proxy
+              value: {{ $proxy.noProxy }}
             - name: HTTP_PROXY
-              value: {{ .Values.driver.httpProxy }}
+              value: {{ $proxy.http }}
+            - name: http_proxy
+              value: {{ $proxy.http }}
+            - name: HTTPS_PROXY
+              value: {{ $proxy.https }}
+            - name: https_proxy
+              value: {{ $proxy.https }}
             {{- end }}
             - name: KUBE_NODE_NAME
               valueFrom:

--- a/helm/azurefile-csi-driver-app/templates/csi-snapshot-controller.yaml
+++ b/helm/azurefile-csi-driver-app/templates/csi-snapshot-controller.yaml
@@ -7,6 +7,13 @@ metadata:
   labels:
     app: {{ .Values.snapshot.snapshotController.name}}
     {{- include "azurefile.labels" . | nindent 4 }}
+{{- with .Values.snapshot.snapshotController.labels }}
+{{ . | toYaml | indent 4 }}
+{{- end }}
+{{- with .Values.snapshot.snapshotController.annotations }}
+  annotations:
+{{ . | toYaml | indent 4 }}
+{{- end }}
 spec:
   replicas: {{ .Values.snapshot.snapshotController.replicas }}
   selector:
@@ -18,6 +25,13 @@ spec:
       labels:
         app: {{ .Values.snapshot.snapshotController.name}}
         {{- include "azurefile.labels" . | nindent 8 }}
+{{- with .Values.snapshot.snapshotController.podLabels }}
+{{ toYaml . | indent 8 }}
+{{- end }}
+{{- with .Values.snapshot.snapshotController.podAnnotations }}
+      annotations:
+{{ toYaml . | indent 8 }}
+{{- end }}
     spec:
       serviceAccountName: {{ .Values.serviceAccount.snapshotController }}
       nodeSelector:

--- a/helm/azurefile-csi-driver-app/templates/rbac-csi-azurefile-controller.yaml
+++ b/helm/azurefile-csi-driver-app/templates/rbac-csi-azurefile-controller.yaml
@@ -108,7 +108,7 @@ rules:
     verbs: ["list", "watch", "create", "update", "patch"]
   - apiGroups: [""]
     resources: ["secrets"]
-    verbs: ["get", "list"]
+    verbs: ["get"]
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshotclasses"]
     verbs: ["get", "list", "watch"]
@@ -187,7 +187,7 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["secrets"]
-    verbs: ["get", "list", "create"]
+    verbs: ["get", "create"]
 
 ---
 kind: ClusterRoleBinding

--- a/helm/azurefile-csi-driver-app/templates/rbac-csi-azurefile-node.yaml
+++ b/helm/azurefile-csi-driver-app/templates/rbac-csi-azurefile-node.yaml
@@ -9,7 +9,7 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["secrets"]
-    verbs: ["get", "list"]
+    verbs: ["get"]
 
 ---
 kind: ClusterRoleBinding

--- a/helm/azurefile-csi-driver-app/values.yaml
+++ b/helm/azurefile-csi-driver-app/values.yaml
@@ -272,6 +272,8 @@ cluster:
     http:
     https:
 
+provider: vintage
+
 test:
   image:
     name: giantswarm/alpine-testing

--- a/helm/azurefile-csi-driver-app/values.yaml
+++ b/helm/azurefile-csi-driver-app/values.yaml
@@ -171,8 +171,6 @@ driver:
   customUserAgent: ""
   userAgentSuffix: "OSS-helm"
   azureGoSDKLogLevel: "" # available values: ""(no logs), DEBUG, INFO, WARNING, ERROR
-  httpsProxy: ""
-  httpProxy: ""
 
 linux:
   enabled: true
@@ -260,6 +258,19 @@ windows:
               operator: NotIn
               values:
                 - virtual-kubelet
+
+# set the HTTP_PROXY, HTTPS_PROXY and NO_PROXY variable
+proxy:
+  noProxy:
+  http:
+  https:
+cluster:
+  # is getting overwritten by the top level proxy if set
+  # These values are generated via cluster-apps-operator
+  proxy:
+    noProxy:
+    http:
+    https:
 
 test:
   image:

--- a/helm/azurefile-csi-driver-app/values.yaml
+++ b/helm/azurefile-csi-driver-app/values.yaml
@@ -9,27 +9,27 @@ image:
   baseRepo: docker.io
   azurefile:
     repository: /giantswarm/azurefile-csi
-    tag: v1.20.0
+    tag: v1.26.0
     pullPolicy: IfNotPresent
   csiProvisioner:
     repository: /giantswarm/csi-provisioner
-    tag: v3.2.0
+    tag: v3.3.0
     pullPolicy: IfNotPresent
   csiAttacher:
     repository: /giantswarm/csi-attacher
-    tag: v3.5.0
+    tag: v4.0.0
     pullPolicy: IfNotPresent
   csiResizer:
     repository: /giantswarm/csi-resizer
-    tag: v1.5.0
+    tag: v1.6.0
     pullPolicy: IfNotPresent
   livenessProbe:
     repository: /giantswarm/livenessprobe
-    tag: v2.7.0
+    tag: v2.8.0
     pullPolicy: IfNotPresent
   nodeDriverRegistrar:
     repository: /giantswarm/csi-node-driver-registrar
-    tag: v2.5.1
+    tag: v2.6.2
     pullPolicy: IfNotPresent
 
 ## Reference to one or more secrets to be used when pulling images
@@ -65,6 +65,10 @@ controller:
   runOnControlPlane: false
   attachRequired: false
   logLevel: 5
+  labels: {}
+  annotations: {}
+  podLabels: {}
+  podAnnotations: {}
   resources:
     csiProvisioner:
       limits:
@@ -118,6 +122,9 @@ controller:
     - key: "node-role.kubernetes.io/controlplane"
       operator: "Exists"
       effect: "NoSchedule"
+    - key: "node-role.kubernetes.io/control-plane"
+      operator: "Exists"
+      effect: "NoSchedule"
 
 node:
   cloudConfigSecretName: azure-cloud-provider
@@ -144,6 +151,10 @@ snapshot:
   snapshotController:
     name: csi-snapshot-controller
     replicas: 2
+    labels: {}
+    annotations: {}
+    podLabels: {}
+    podAnnotations: {}
     resources:
       limits:
         cpu: 1
@@ -160,6 +171,8 @@ driver:
   customUserAgent: ""
   userAgentSuffix: "OSS-helm"
   azureGoSDKLogLevel: "" # available values: ""(no logs), DEBUG, INFO, WARNING, ERROR
+  httpsProxy: ""
+  httpProxy: ""
 
 linux:
   enabled: true
@@ -169,6 +182,10 @@ linux:
   kubeconfig: ""
   distro: debian # available values: debian, fedora
   mountPermissions: 0777
+  labels: {}
+  annotations: {}
+  podLabels: {}
+  podAnnotations: {}
   resources:
     livenessProbe:
       limits:
@@ -206,16 +223,20 @@ windows:
   dsName: csi-azurefile-node-win # daemonset name
   kubelet: 'C:\var\lib\kubelet'
   kubeconfig: ""
+  labels: {}
+  annotations: {}
+  podLabels: {}
+  podAnnotations: {}
   resources:
     livenessProbe:
       limits:
-        memory: 100Mi
+        memory: 150Mi
       requests:
         cpu: 10m
         memory: 40Mi
     nodeDriverRegistrar:
       limits:
-        memory: 100Mi
+        memory: 150Mi
       requests:
         cpu: 30m
         memory: 40Mi


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/24587

#### App Changes

* Sync with upstream 1.26.0 chart
* bump components versions
  * azurefile-csi to `1.26.0`
  * csi-provisioner to `3.3.0`
  * csi-attacher to `4.0.0`
  * csi-resizer to `1.6.0`
  * livenessprobe to `2.8.0`
  * csi-node-driver-registrar to `2.6.2`
* increase api qps limit of csi-provisioner and csi-attacher 
* increase api qps for azurefile kubeclient
* add support for labels, annotations, podLabels and podAnnotations 
* Remove `list` rbac for secrets
* add node-role.kubernetes.io/control-plane toleration
* add support for http/s proxy 
* Make `AZURE_CREDENTIAL_FILE` depends on `.Values.provider` 

#### Other changes in upstream changelog

* add accountAccessTier parameter in storage class
* add requireInfraEncryption parameter in storage class 
* enable disableDeleteRetentionPolicy on standard file share
* fix: create private dns zone failed using managed azure file csi driver 
* fix: use force unmount to fix unmount NFS volume stuck issue 
* fix: target is busy unmount failure

#### Testing

* CAPZ: https://github.com/giantswarm/giantswarm/issues/24587#issuecomment-1429540396
* VINTAGE: https://github.com/giantswarm/giantswarm/issues/24587#issuecomment-1429816605