### PR TITLE
- Disable PSPs for k8s 1.25 and newer.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Disable PSPs for k8s 1.25 and newer.
+
 ## [1.26.0-gs1] - 2023-02-14
 
 ### Changed

--- a/helm/azurefile-csi-driver-app/templates/csi-azurefile-controller-psp.yaml
+++ b/helm/azurefile-csi-driver-app/templates/csi-azurefile-controller-psp.yaml
@@ -65,4 +65,4 @@ roleRef:
   kind: ClusterRole
   name: csi-{{ .Values.rbac.name }}-controller-psp
   apiGroup: rbac.authorization.k8s.io
-{{ end }}
+{{- end }}

--- a/helm/azurefile-csi-driver-app/templates/csi-azurefile-controller-psp.yaml
+++ b/helm/azurefile-csi-driver-app/templates/csi-azurefile-controller-psp.yaml
@@ -1,3 +1,4 @@
+{{- if le (int .Capabilities.KubeVersion.Minor) 24 }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
@@ -64,3 +65,4 @@ roleRef:
   kind: ClusterRole
   name: csi-{{ .Values.rbac.name }}-controller-psp
   apiGroup: rbac.authorization.k8s.io
+{{ end }}

--- a/helm/azurefile-csi-driver-app/templates/csi-azurefile-node-psp.yaml
+++ b/helm/azurefile-csi-driver-app/templates/csi-azurefile-node-psp.yaml
@@ -1,3 +1,4 @@
+{{- if le (int .Capabilities.KubeVersion.Minor) 24 }}
 {{- if .Values.linux.enabled}}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
@@ -62,4 +63,5 @@ roleRef:
   kind: ClusterRole
   name: csi-{{ .Values.rbac.name }}-node-psp
   apiGroup: rbac.authorization.k8s.io
+{{ end }}
 {{ end }}

--- a/helm/azurefile-csi-driver-app/templates/csi-azurefile-node-psp.yaml
+++ b/helm/azurefile-csi-driver-app/templates/csi-azurefile-node-psp.yaml
@@ -64,4 +64,4 @@ roleRef:
   name: csi-{{ .Values.rbac.name }}-node-psp
   apiGroup: rbac.authorization.k8s.io
 {{ end }}
-{{ end }}
+{{- end }}


### PR DESCRIPTION
in k8s 1.25 there is no PodSecurityPolicy

this PR disables the PSP for 1.25