### PR TITLE
Add storage classes for CAPZ

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 ### Added
 
 - Add `global.podSecurityStandards.enforced` value for PSS migration.
+- Add storage classes for CAPZ.
 
 ## [1.26.0-gs2] - 2023-05-03
 

--- a/helm/azurefile-csi-driver-app/templates/csi-azurefile-node-windows.yaml
+++ b/helm/azurefile-csi-driver-app/templates/csi-azurefile-node-windows.yaml
@@ -176,7 +176,7 @@ spec:
                   fieldPath: spec.nodeName
             - name: AZURE_GO_SDK_LOG_LEVEL
               value: {{ .Values.driver.azureGoSDKLogLevel }}
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          imagePullPolicy: {{ .Values.image.azurefile.pullPolicy }}
           volumeMounts:
             - name: kubelet-dir
               mountPath: "C:\\var\\lib\\kubelet"

--- a/helm/azurefile-csi-driver-app/templates/storage-class.yaml
+++ b/helm/azurefile-csi-driver-app/templates/storage-class.yaml
@@ -1,0 +1,33 @@
+{{- if and .Values.provider (eq .Values.provider "capz") -}}
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: af-premium
+provisioner: file.csi.azure.com
+mountOptions:
+  - dir_mode=0755
+  - file_mode=0755
+  - uid=1000
+  - gid=1000
+parameters:
+  skuName: Premium_LRS
+allowVolumeExpansion: true
+reclaimPolicy: Delete
+volumeBindingMode: Immediate
+---
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: af-standard
+provisioner: file.csi.azure.com
+mountOptions:
+  - dir_mode=0755
+  - file_mode=0755
+  - uid=1000
+  - gid=1000
+parameters:
+  skuName: Standard_LRS
+allowVolumeExpansion: true
+reclaimPolicy: Delete
+volumeBindingMode: Immediate
+{{- end }}


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/3013

I deployed `azurefile-csi-driver-app` to my WC and created these storage classes. I created PVCs with those SCs and mounted them to pods. I checked Azure and observed them as `SMB File share`. Their tiers were as expected.

I am not sure about the names of storage classes. I just used the same as vintage. See https://github.com/giantswarm/azure-operator/blob/8a49ffc9e4545c423b2de34d592116229b171f36/service/controller/templates/ignition/default_storage_class.go#L74

Note that the default SC will be `managed-premium` provisioned by disk driver. https://github.com/giantswarm/azuredisk-csi-driver-app/blob/main/helm/azuredisk-csi-driver-app/templates/azuredisk-controller/storage-class.yaml#L5

