### PR TITLE
Configure gsoci.azurecr.io as the registry to use by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,19 +7,9 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
-## [1.26.0-gs3] - 2023-12-14
-
-### Added
-
-- Add team label in resources.
-- Add `global.podSecurityStandards.enforced` value for PSS migration.
-- Add storage classes for CAPZ.
-
-## [1.26.0-gs2] - 2023-05-03
-
 ### Changed
 
-- Disable PSPs for k8s 1.25 and newer.
+- Configure `gsoci.azurecr.io` as the default container image registry.
 
 ## [1.26.0-gs1] - 2023-02-14
 
@@ -39,7 +29,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 * Remove `list` rbac for secrets
 * add node-role.kubernetes.io/control-plane toleration
 * add support for http/s proxy 
-* Make `AZURE_CREDENTIAL_FILE` depends on `.Values.provider` 
+* Make `AZURE_CREDENTIAL_FILE` depends on `.Values.provider`
 
 ## [1.20.0-gs1] - 2022-08-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,21 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+- Configure `gsoci.azurecr.io` as the default container image registry.
+
+## [1.26.0-gs3] - 2023-12-14
+
+### Added
+
+- Add team label in resources.
+- Add `global.podSecurityStandards.enforced` value for PSS migration.
+- Add storage classes for CAPZ.
+
+## [1.26.0-gs2] - 2023-05-03
+
 ### Changed
 
-- Configure `gsoci.azurecr.io` as the default container image registry.
+- Disable PSPs for k8s 1.25 and newer.
 
 ## [1.26.0-gs1] - 2023-02-14
 

--- a/helm/azurefile-csi-driver-app/values.yaml
+++ b/helm/azurefile-csi-driver-app/values.yaml
@@ -6,7 +6,7 @@ name: azurefile-csi
 serviceType: managed
 
 image:
-  baseRepo: docker.io
+  baseRepo: gsoci.azurecr.io
   azurefile:
     repository: /giantswarm/azurefile-csi
     tag: v1.26.0


### PR DESCRIPTION
Towards

- https://github.com/giantswarm/roadmap/issues/3017

This PR replaces any occurrence of `docker.io` in `values.yaml` files with `gsoci.azurecr.io`,
to make the new ACR registry the default one.
